### PR TITLE
HitController 리팩토링: 로깅 개선 및 중복 제거

### DIFF
--- a/src/main/kotlin/com/example/hits/service/HitService.kt
+++ b/src/main/kotlin/com/example/hits/service/HitService.kt
@@ -1,7 +1,7 @@
 package com.example.hits.service
 
 import com.example.hits.domain.repository.HitRepository
-import com.example.hits.web.controller.badge.HitV2Controller
+import com.example.hits.util.MEDIA_TYPE_SVG
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
@@ -52,7 +52,7 @@ class HitService(
     """.trimIndent()
 
         return ResponseEntity.badRequest()
-            .contentType(MediaType.parseMediaType(HitV2Controller.MEDIA_TYPE_SVG))
+            .contentType(MediaType.parseMediaType(MEDIA_TYPE_SVG))
             .body(svg)
     }
 }

--- a/src/main/kotlin/com/example/hits/util/Const.kt
+++ b/src/main/kotlin/com/example/hits/util/Const.kt
@@ -1,0 +1,3 @@
+package com.example.hits.util
+
+const val MEDIA_TYPE_SVG = "image/svg+xml"

--- a/src/main/kotlin/com/example/hits/web/controller/badge/HitV1Controller.kt
+++ b/src/main/kotlin/com/example/hits/web/controller/badge/HitV1Controller.kt
@@ -1,11 +1,11 @@
 package com.example.hits.web.controller.badge
 
 import com.example.hits.service.HitService
+import com.example.hits.util.MEDIA_TYPE_SVG
 import com.example.hits.web.api.API_V1
+import com.example.hits.web.controller.badge.util.svgResponse
 import com.example.hits.web.util.SvgBadgeGenerator
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,10 +17,8 @@ import org.springframework.web.bind.annotation.RestController
 class HitV1Controller(
     private val hitService: HitService
 ) {
-    val logger = LoggerFactory.getLogger(HitV1Controller::class.java)
-
     companion object {
-        const val MEDIA_TYPE_SVG = "image/svg+xml"
+        private val logger = LoggerFactory.getLogger(HitV1Controller::class.java)
     }
 
     @GetMapping("/badge", produces = [MEDIA_TYPE_SVG])
@@ -29,8 +27,9 @@ class HitV1Controller(
         @RequestParam(required = false, defaultValue = "blue") color: String,
         @RequestParam(required = false, defaultValue = "zap") icon: String
     ): ResponseEntity<String> {
-        hitService.validateParams(url, "", color, icon)?.let {
-            return it
+        val error = hitService.validateParams(url, "", color, icon)
+        if(error != null) {
+            return error
         }
 
         val count = hitService.increment(url)
@@ -41,11 +40,6 @@ class HitV1Controller(
 
         val svg = SvgBadgeGenerator.generateV1(title, count, color, icon)
 
-        return ResponseEntity.ok()
-            .contentType(MediaType.parseMediaType(MEDIA_TYPE_SVG))
-            .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
-            .header(HttpHeaders.PRAGMA, "no-cache")
-            .header(HttpHeaders.EXPIRES, "0")
-            .body(svg)
+        return svgResponse(svg)
     }
 }

--- a/src/main/kotlin/com/example/hits/web/controller/badge/HitV2Controller.kt
+++ b/src/main/kotlin/com/example/hits/web/controller/badge/HitV2Controller.kt
@@ -1,11 +1,11 @@
 package com.example.hits.web.controller.badge
 
 import com.example.hits.service.HitService
+import com.example.hits.util.MEDIA_TYPE_SVG
 import com.example.hits.web.api.API_V2
+import com.example.hits.web.controller.badge.util.svgResponse
 import com.example.hits.web.util.SvgBadgeGenerator
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,21 +17,20 @@ import org.springframework.web.bind.annotation.RestController
 class HitV2Controller(
     private val hitService: HitService
 ) {
-    val logger = LoggerFactory.getLogger(HitV2Controller::class.java)
-
     companion object {
-        const val MEDIA_TYPE_SVG = "image/svg+xml"
+        private val logger = LoggerFactory.getLogger(HitV2Controller::class.java)
     }
 
     @GetMapping("/badge", produces = [MEDIA_TYPE_SVG])
     fun incrementAndGetBadge(
         @RequestParam url: String,
-        @RequestParam(required = false) title: String, // 사용자가 지정한 title
+        @RequestParam(required = false) title: String,
         @RequestParam(required = false, defaultValue = "blue") color: String,
         @RequestParam(required = false, defaultValue = "zap") icon: String
     ): ResponseEntity<String> {
-        hitService.validateParams(url, title, color, icon)?.let {
-            return it
+        val error = hitService.validateParams(url, title, color, icon)
+        if(error != null) {
+            return error
         }
 
         val count = hitService.getRecentCounts(url)
@@ -42,11 +41,6 @@ class HitV2Controller(
 
         val svg = SvgBadgeGenerator.generateV2(resolvedTitle, icon, color, count)
 
-        return ResponseEntity.ok()
-            .contentType(MediaType.parseMediaType(MEDIA_TYPE_SVG))
-            .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
-            .header(HttpHeaders.PRAGMA, "no-cache")
-            .header(HttpHeaders.EXPIRES, "0")
-            .body(svg)
+        return svgResponse(svg)
     }
 }

--- a/src/main/kotlin/com/example/hits/web/controller/badge/util/SvgResponse.kt
+++ b/src/main/kotlin/com/example/hits/web/controller/badge/util/SvgResponse.kt
@@ -1,0 +1,14 @@
+package com.example.hits.web.controller.badge.util
+
+import com.example.hits.util.MEDIA_TYPE_SVG
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+
+fun svgResponse(body: String): ResponseEntity<String> =
+    ResponseEntity.ok()
+        .contentType(MediaType.parseMediaType(MEDIA_TYPE_SVG))
+        .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+        .header(HttpHeaders.PRAGMA, "no-cache")
+        .header(HttpHeaders.EXPIRES, "0")
+        .body(body)


### PR DESCRIPTION
## 변경 사항
- V1/V2 컨트롤러에서 공통 응답 반환 로직을 `svgResponse()`로 추출
- `validateParams()` 결과 처리 방식 개선 (`null` 체크 후 즉시 반환)
- title 자동 추출 로직 단순화 (`substringAfterLast("/")`)
- 로그 출력 시 title 기준 출력
- V2의 잘못된 Logger 클래스 대상 수정

## 변경 이유
- 컨벤션 일치 및 로그 초기화 일관성 확보
- 반복되는 코드 제거 및 응답 처리 단순화
- 전체적으로 가독성과 유지보수성 향상

## 테스트
- 컨트롤러 Kotest 통과
- 직접 URL 파라미터 조합 테스트로 정상 SVG 반환 확인