### PR TITLE
파라미터 검증 유틸 분리 및 Hit 컨트롤러 리팩토링

### DIFF
--- a/src/main/kotlin/com/example/hits/service/HitService.kt
+++ b/src/main/kotlin/com/example/hits/service/HitService.kt
@@ -1,9 +1,6 @@
 package com.example.hits.service
 
 import com.example.hits.domain.repository.HitRepository
-import com.example.hits.util.MEDIA_TYPE_SVG
-import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -16,43 +13,7 @@ class HitService(
     }
 
     fun getRecentCounts(url: String): Map<LocalDate, Int> {
+        repository.increment(url)
         return repository.getRecentCounts(url)
-    }
-
-    fun validateParams(
-        url: String,
-        title: String,
-        color: String,
-        icon: String
-    ): ResponseEntity<String>? {
-        if (url.length > 60) {
-            return errorSvg("url must be ≤ 60 characters")
-        }
-
-        if (title.length > 30) {
-            return errorSvg("title must be ≤ 30 characters")
-        }
-
-        if (!(color.length == 3 || color.length == 6)) {
-            return errorSvg("color must be 3 or 6 characters")
-        }
-
-        if (icon.length > 5) {
-            return errorSvg("icon must be ≤ 5 characters")
-        }
-
-        return null
-    }
-
-    private fun errorSvg(message: String): ResponseEntity<String> {
-        val svg = """
-        <svg xmlns="http://www.w3.org/2000/svg" width="360" height="20">
-            <text x="0" y="15" fill="red">Error: $message</text>
-        </svg>
-    """.trimIndent()
-
-        return ResponseEntity.badRequest()
-            .contentType(MediaType.parseMediaType(MEDIA_TYPE_SVG))
-            .body(svg)
     }
 }

--- a/src/main/kotlin/com/example/hits/service/ParamValidation.kt
+++ b/src/main/kotlin/com/example/hits/service/ParamValidation.kt
@@ -3,9 +3,11 @@ package com.example.hits.service
 import com.example.hits.util.MEDIA_TYPE_SVG
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
 
-object Validation {
-    fun params(
+@Service
+class ParamValidation {
+    fun check(
         url: String,
         title: String,
         color: String,

--- a/src/main/kotlin/com/example/hits/service/Validation.kt
+++ b/src/main/kotlin/com/example/hits/service/Validation.kt
@@ -1,0 +1,42 @@
+package com.example.hits.service
+
+import com.example.hits.util.MEDIA_TYPE_SVG
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+
+object Validation {
+    fun params(
+        url: String,
+        title: String,
+        color: String,
+        icon: String
+    ): ResponseEntity<String>? =
+        validateUrl(url)
+            ?: validateTitle(title)
+            ?: validateColor(color)
+            ?: validateIcon(icon)
+
+    private fun validateUrl(url: String): ResponseEntity<String>? =
+        if (url.length > 60) errorSvg("url must be ≤ 60 characters") else null
+
+    private fun validateTitle(title: String): ResponseEntity<String>? =
+        if (title.length > 30) errorSvg("title must be ≤ 30 characters") else null
+
+    private fun validateColor(color: String): ResponseEntity<String>? =
+        if (!(color.length == 3 || color.length == 6)) errorSvg("color must be 3 or 6 characters") else null
+
+    private fun validateIcon(icon: String): ResponseEntity<String>? =
+        if (icon.length > 5) errorSvg("icon must be ≤ 5 characters") else null
+
+    private fun errorSvg(message: String): ResponseEntity<String> {
+        val svg = """
+        <svg xmlns="http://www.w3.org/2000/svg" width="360" height="20">
+            <text x="0" y="15" fill="red">Error: $message</text>
+        </svg>
+    """.trimIndent()
+
+        return ResponseEntity.badRequest()
+            .contentType(MediaType.parseMediaType(MEDIA_TYPE_SVG))
+            .body(svg)
+    }
+}

--- a/src/main/kotlin/com/example/hits/web/controller/badge/HitV1Controller.kt
+++ b/src/main/kotlin/com/example/hits/web/controller/badge/HitV1Controller.kt
@@ -1,7 +1,7 @@
 package com.example.hits.web.controller.badge
 
 import com.example.hits.service.HitService
-import com.example.hits.service.Validation
+import com.example.hits.service.ParamValidation
 import com.example.hits.util.MEDIA_TYPE_SVG
 import com.example.hits.web.api.API_V1
 import com.example.hits.web.controller.badge.util.svgResponse
@@ -16,7 +16,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(API_V1)
 class HitV1Controller(
-    private val hitService: HitService
+    private val hitService: HitService,
+    private val paramValidation: ParamValidation
 ) {
     companion object {
         private val logger = LoggerFactory.getLogger(HitV1Controller::class.java)
@@ -28,7 +29,7 @@ class HitV1Controller(
         @RequestParam(required = false, defaultValue = "blue") color: String,
         @RequestParam(required = false, defaultValue = "zap") icon: String
     ): ResponseEntity<String> {
-        val error = Validation.params(url, "", color, icon)
+        val error = paramValidation.check(url, "", color, icon)
         if(error != null) {
             return error
         }

--- a/src/main/kotlin/com/example/hits/web/controller/badge/HitV1Controller.kt
+++ b/src/main/kotlin/com/example/hits/web/controller/badge/HitV1Controller.kt
@@ -1,6 +1,7 @@
 package com.example.hits.web.controller.badge
 
 import com.example.hits.service.HitService
+import com.example.hits.service.Validation
 import com.example.hits.util.MEDIA_TYPE_SVG
 import com.example.hits.web.api.API_V1
 import com.example.hits.web.controller.badge.util.svgResponse
@@ -27,7 +28,7 @@ class HitV1Controller(
         @RequestParam(required = false, defaultValue = "blue") color: String,
         @RequestParam(required = false, defaultValue = "zap") icon: String
     ): ResponseEntity<String> {
-        val error = hitService.validateParams(url, "", color, icon)
+        val error = Validation.params(url, "", color, icon)
         if(error != null) {
             return error
         }

--- a/src/main/kotlin/com/example/hits/web/controller/badge/HitV2Controller.kt
+++ b/src/main/kotlin/com/example/hits/web/controller/badge/HitV2Controller.kt
@@ -1,6 +1,7 @@
 package com.example.hits.web.controller.badge
 
 import com.example.hits.service.HitService
+import com.example.hits.service.Validation
 import com.example.hits.util.MEDIA_TYPE_SVG
 import com.example.hits.web.api.API_V2
 import com.example.hits.web.controller.badge.util.svgResponse
@@ -28,7 +29,7 @@ class HitV2Controller(
         @RequestParam(required = false, defaultValue = "blue") color: String,
         @RequestParam(required = false, defaultValue = "zap") icon: String
     ): ResponseEntity<String> {
-        val error = hitService.validateParams(url, title, color, icon)
+        val error = Validation.params(url, title, color, icon)
         if(error != null) {
             return error
         }

--- a/src/main/kotlin/com/example/hits/web/controller/badge/HitV2Controller.kt
+++ b/src/main/kotlin/com/example/hits/web/controller/badge/HitV2Controller.kt
@@ -1,7 +1,7 @@
 package com.example.hits.web.controller.badge
 
 import com.example.hits.service.HitService
-import com.example.hits.service.Validation
+import com.example.hits.service.ParamValidation
 import com.example.hits.util.MEDIA_TYPE_SVG
 import com.example.hits.web.api.API_V2
 import com.example.hits.web.controller.badge.util.svgResponse
@@ -16,7 +16,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(API_V2)
 class HitV2Controller(
-    private val hitService: HitService
+    private val hitService: HitService,
+    private val paramValidation: ParamValidation
 ) {
     companion object {
         private val logger = LoggerFactory.getLogger(HitV2Controller::class.java)
@@ -29,7 +30,7 @@ class HitV2Controller(
         @RequestParam(required = false, defaultValue = "blue") color: String,
         @RequestParam(required = false, defaultValue = "zap") icon: String
     ): ResponseEntity<String> {
-        val error = Validation.params(url, title, color, icon)
+        val error = paramValidation.check(url, title, color, icon)
         if(error != null) {
             return error
         }

--- a/src/test/kotlin/com/example/hits/controller/HitControllerV1Test.kt
+++ b/src/test/kotlin/com/example/hits/controller/HitControllerV1Test.kt
@@ -1,25 +1,23 @@
 package com.example.hits.controller
 
 import com.example.hits.service.HitService
+import com.example.hits.service.ParamValidation
 import com.example.hits.web.api.API_V1
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
-import io.mockk.mockk
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Import(HitControllerV1Test.TestConfig::class)
+@Import(TestConfig::class)
 class HitControllerV1Test : BehaviorSpec() {
 
     @Autowired
@@ -28,12 +26,22 @@ class HitControllerV1Test : BehaviorSpec() {
     @Autowired
     private lateinit var hitService: HitService
 
+    @Autowired
+    private lateinit var paramValidation: ParamValidation
+
     init {
         extension(SpringExtension)
 
         beforeSpec {
             every { hitService.increment("https://github.com/test/repo") } returns 42
-            every { hitService.validateParams("https://github.com/test/repo", any(), any(), any()) } returns null
+            every {
+                paramValidation.check(
+                    eq("https://github.com/test/repo"),
+                    any(),
+                    any(),
+                    any()
+                )
+            } returns null
         }
 
         given("GET $API_V1") {
@@ -53,11 +61,5 @@ class HitControllerV1Test : BehaviorSpec() {
                 }
             }
         }
-    }
-
-    @TestConfiguration
-    class TestConfig {
-        @Bean
-        fun hitService(): HitService = mockk(relaxed = true)
     }
 }

--- a/src/test/kotlin/com/example/hits/controller/TestConfig.kt
+++ b/src/test/kotlin/com/example/hits/controller/TestConfig.kt
@@ -1,0 +1,16 @@
+package com.example.hits.controller
+
+import com.example.hits.service.HitService
+import com.example.hits.service.ParamValidation
+import io.mockk.mockk
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+@TestConfiguration
+class TestConfig {
+    @Bean
+    fun hitService(): HitService = mockk(relaxed = true)
+
+    @Bean
+    fun paramValidation(): ParamValidation = mockk(relaxed = true)
+}


### PR DESCRIPTION
## 변경 사항
- `HitService` 내부 파라미터 유효성 검증 로직을 `ParamValidation.kt`로 분리
   - `check()`을 통해 오류 응답 SVG를 생성하고 바로 반환할 수 있도록 단순화
   - `HitV1Controller` / `HitV2Controller` 모두 `svgResponse()` 및 `check()` 방식으로 공통 처리
- V2에서 title 비어있을 경우 `url`에서 자동 추출
- 테스트 코드 전면 수정 및 검증 완료

## 기대 효과
- 서비스 계층과의 의존성 최소화로 유닛 테스트 용이
- 컨트롤러 로직 간결화 및 공통화
- 추후 파라미터 검증 유틸을 다른 서비스에서도 재활용 가능
- 클린 아키텍처 기반 확장성 확보