### PR TITLE
Hit 뱃지 시스템 리팩토링 및 검증 유틸 분리

### DIFF
--- a/src/main/kotlin/com/example/hits/service/HitService.kt
+++ b/src/main/kotlin/com/example/hits/service/HitService.kt
@@ -1,7 +1,7 @@
 package com.example.hits.service
 
 import com.example.hits.domain.repository.HitRepository
-import com.example.hits.web.controller.badge.HitV2Controller
+import com.example.hits.util.MEDIA_TYPE_SVG
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
@@ -52,7 +52,7 @@ class HitService(
     """.trimIndent()
 
         return ResponseEntity.badRequest()
-            .contentType(MediaType.parseMediaType(HitV2Controller.MEDIA_TYPE_SVG))
+            .contentType(MediaType.parseMediaType(MEDIA_TYPE_SVG))
             .body(svg)
     }
 }

--- a/src/main/kotlin/com/example/hits/service/HitService.kt
+++ b/src/main/kotlin/com/example/hits/service/HitService.kt
@@ -1,9 +1,6 @@
 package com.example.hits.service
 
 import com.example.hits.domain.repository.HitRepository
-import com.example.hits.util.MEDIA_TYPE_SVG
-import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -16,43 +13,7 @@ class HitService(
     }
 
     fun getRecentCounts(url: String): Map<LocalDate, Int> {
+        repository.increment(url)
         return repository.getRecentCounts(url)
-    }
-
-    fun validateParams(
-        url: String,
-        title: String,
-        color: String,
-        icon: String
-    ): ResponseEntity<String>? {
-        if (url.length > 60) {
-            return errorSvg("url must be ≤ 60 characters")
-        }
-
-        if (title.length > 30) {
-            return errorSvg("title must be ≤ 30 characters")
-        }
-
-        if (!(color.length == 3 || color.length == 6)) {
-            return errorSvg("color must be 3 or 6 characters")
-        }
-
-        if (icon.length > 5) {
-            return errorSvg("icon must be ≤ 5 characters")
-        }
-
-        return null
-    }
-
-    private fun errorSvg(message: String): ResponseEntity<String> {
-        val svg = """
-        <svg xmlns="http://www.w3.org/2000/svg" width="360" height="20">
-            <text x="0" y="15" fill="red">Error: $message</text>
-        </svg>
-    """.trimIndent()
-
-        return ResponseEntity.badRequest()
-            .contentType(MediaType.parseMediaType(MEDIA_TYPE_SVG))
-            .body(svg)
     }
 }

--- a/src/main/kotlin/com/example/hits/service/ParamValidation.kt
+++ b/src/main/kotlin/com/example/hits/service/ParamValidation.kt
@@ -1,0 +1,44 @@
+package com.example.hits.service
+
+import com.example.hits.util.MEDIA_TYPE_SVG
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+
+@Service
+class ParamValidation {
+    fun check(
+        url: String,
+        title: String,
+        color: String,
+        icon: String
+    ): ResponseEntity<String>? =
+        validateUrl(url)
+            ?: validateTitle(title)
+            ?: validateColor(color)
+            ?: validateIcon(icon)
+
+    private fun validateUrl(url: String): ResponseEntity<String>? =
+        if (url.length > 60) errorSvg("url must be ≤ 60 characters") else null
+
+    private fun validateTitle(title: String): ResponseEntity<String>? =
+        if (title.length > 30) errorSvg("title must be ≤ 30 characters") else null
+
+    private fun validateColor(color: String): ResponseEntity<String>? =
+        if (!(color.length == 3 || color.length == 6)) errorSvg("color must be 3 or 6 characters") else null
+
+    private fun validateIcon(icon: String): ResponseEntity<String>? =
+        if (icon.length > 5) errorSvg("icon must be ≤ 5 characters") else null
+
+    private fun errorSvg(message: String): ResponseEntity<String> {
+        val svg = """
+        <svg xmlns="http://www.w3.org/2000/svg" width="360" height="20">
+            <text x="0" y="15" fill="red">Error: $message</text>
+        </svg>
+    """.trimIndent()
+
+        return ResponseEntity.badRequest()
+            .contentType(MediaType.parseMediaType(MEDIA_TYPE_SVG))
+            .body(svg)
+    }
+}

--- a/src/main/kotlin/com/example/hits/util/Const.kt
+++ b/src/main/kotlin/com/example/hits/util/Const.kt
@@ -1,0 +1,3 @@
+package com.example.hits.util
+
+const val MEDIA_TYPE_SVG = "image/svg+xml"

--- a/src/main/kotlin/com/example/hits/web/controller/badge/HitV1Controller.kt
+++ b/src/main/kotlin/com/example/hits/web/controller/badge/HitV1Controller.kt
@@ -1,6 +1,7 @@
 package com.example.hits.web.controller.badge
 
 import com.example.hits.service.HitService
+import com.example.hits.service.ParamValidation
 import com.example.hits.util.MEDIA_TYPE_SVG
 import com.example.hits.web.api.API_V1
 import com.example.hits.web.controller.badge.util.svgResponse
@@ -15,7 +16,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(API_V1)
 class HitV1Controller(
-    private val hitService: HitService
+    private val hitService: HitService,
+    private val paramValidation: ParamValidation
 ) {
     companion object {
         private val logger = LoggerFactory.getLogger(HitV1Controller::class.java)
@@ -27,7 +29,7 @@ class HitV1Controller(
         @RequestParam(required = false, defaultValue = "blue") color: String,
         @RequestParam(required = false, defaultValue = "zap") icon: String
     ): ResponseEntity<String> {
-        val error = hitService.validateParams(url, "", color, icon)
+        val error = paramValidation.check(url, "", color, icon)
         if(error != null) {
             return error
         }

--- a/src/main/kotlin/com/example/hits/web/controller/badge/HitV1Controller.kt
+++ b/src/main/kotlin/com/example/hits/web/controller/badge/HitV1Controller.kt
@@ -1,11 +1,11 @@
 package com.example.hits.web.controller.badge
 
 import com.example.hits.service.HitService
+import com.example.hits.util.MEDIA_TYPE_SVG
 import com.example.hits.web.api.API_V1
+import com.example.hits.web.controller.badge.util.svgResponse
 import com.example.hits.web.util.SvgBadgeGenerator
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,10 +17,8 @@ import org.springframework.web.bind.annotation.RestController
 class HitV1Controller(
     private val hitService: HitService
 ) {
-    val logger = LoggerFactory.getLogger(HitV1Controller::class.java)
-
     companion object {
-        const val MEDIA_TYPE_SVG = "image/svg+xml"
+        private val logger = LoggerFactory.getLogger(HitV1Controller::class.java)
     }
 
     @GetMapping("/badge", produces = [MEDIA_TYPE_SVG])
@@ -29,8 +27,9 @@ class HitV1Controller(
         @RequestParam(required = false, defaultValue = "blue") color: String,
         @RequestParam(required = false, defaultValue = "zap") icon: String
     ): ResponseEntity<String> {
-        hitService.validateParams(url, "", color, icon)?.let {
-            return it
+        val error = hitService.validateParams(url, "", color, icon)
+        if(error != null) {
+            return error
         }
 
         val count = hitService.increment(url)
@@ -41,11 +40,6 @@ class HitV1Controller(
 
         val svg = SvgBadgeGenerator.generateV1(title, count, color, icon)
 
-        return ResponseEntity.ok()
-            .contentType(MediaType.parseMediaType(MEDIA_TYPE_SVG))
-            .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
-            .header(HttpHeaders.PRAGMA, "no-cache")
-            .header(HttpHeaders.EXPIRES, "0")
-            .body(svg)
+        return svgResponse(svg)
     }
 }

--- a/src/main/kotlin/com/example/hits/web/controller/badge/HitV2Controller.kt
+++ b/src/main/kotlin/com/example/hits/web/controller/badge/HitV2Controller.kt
@@ -1,11 +1,11 @@
 package com.example.hits.web.controller.badge
 
 import com.example.hits.service.HitService
+import com.example.hits.util.MEDIA_TYPE_SVG
 import com.example.hits.web.api.API_V2
+import com.example.hits.web.controller.badge.util.svgResponse
 import com.example.hits.web.util.SvgBadgeGenerator
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,21 +17,20 @@ import org.springframework.web.bind.annotation.RestController
 class HitV2Controller(
     private val hitService: HitService
 ) {
-    val logger = LoggerFactory.getLogger(HitV2Controller::class.java)
-
     companion object {
-        const val MEDIA_TYPE_SVG = "image/svg+xml"
+        private val logger = LoggerFactory.getLogger(HitV2Controller::class.java)
     }
 
     @GetMapping("/badge", produces = [MEDIA_TYPE_SVG])
     fun incrementAndGetBadge(
         @RequestParam url: String,
-        @RequestParam(required = false) title: String, // 사용자가 지정한 title
+        @RequestParam(required = false) title: String,
         @RequestParam(required = false, defaultValue = "blue") color: String,
         @RequestParam(required = false, defaultValue = "zap") icon: String
     ): ResponseEntity<String> {
-        hitService.validateParams(url, title, color, icon)?.let {
-            return it
+        val error = hitService.validateParams(url, title, color, icon)
+        if(error != null) {
+            return error
         }
 
         val count = hitService.getRecentCounts(url)
@@ -42,11 +41,6 @@ class HitV2Controller(
 
         val svg = SvgBadgeGenerator.generateV2(resolvedTitle, icon, color, count)
 
-        return ResponseEntity.ok()
-            .contentType(MediaType.parseMediaType(MEDIA_TYPE_SVG))
-            .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
-            .header(HttpHeaders.PRAGMA, "no-cache")
-            .header(HttpHeaders.EXPIRES, "0")
-            .body(svg)
+        return svgResponse(svg)
     }
 }

--- a/src/main/kotlin/com/example/hits/web/controller/badge/HitV2Controller.kt
+++ b/src/main/kotlin/com/example/hits/web/controller/badge/HitV2Controller.kt
@@ -1,6 +1,7 @@
 package com.example.hits.web.controller.badge
 
 import com.example.hits.service.HitService
+import com.example.hits.service.ParamValidation
 import com.example.hits.util.MEDIA_TYPE_SVG
 import com.example.hits.web.api.API_V2
 import com.example.hits.web.controller.badge.util.svgResponse
@@ -15,7 +16,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(API_V2)
 class HitV2Controller(
-    private val hitService: HitService
+    private val hitService: HitService,
+    private val paramValidation: ParamValidation
 ) {
     companion object {
         private val logger = LoggerFactory.getLogger(HitV2Controller::class.java)
@@ -28,7 +30,7 @@ class HitV2Controller(
         @RequestParam(required = false, defaultValue = "blue") color: String,
         @RequestParam(required = false, defaultValue = "zap") icon: String
     ): ResponseEntity<String> {
-        val error = hitService.validateParams(url, title, color, icon)
+        val error = paramValidation.check(url, title, color, icon)
         if(error != null) {
             return error
         }

--- a/src/main/kotlin/com/example/hits/web/controller/badge/util/SvgResponse.kt
+++ b/src/main/kotlin/com/example/hits/web/controller/badge/util/SvgResponse.kt
@@ -1,0 +1,14 @@
+package com.example.hits.web.controller.badge.util
+
+import com.example.hits.util.MEDIA_TYPE_SVG
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+
+fun svgResponse(body: String): ResponseEntity<String> =
+    ResponseEntity.ok()
+        .contentType(MediaType.parseMediaType(MEDIA_TYPE_SVG))
+        .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+        .header(HttpHeaders.PRAGMA, "no-cache")
+        .header(HttpHeaders.EXPIRES, "0")
+        .body(body)

--- a/src/test/kotlin/com/example/hits/controller/HitControllerV1Test.kt
+++ b/src/test/kotlin/com/example/hits/controller/HitControllerV1Test.kt
@@ -1,25 +1,23 @@
 package com.example.hits.controller
 
 import com.example.hits.service.HitService
+import com.example.hits.service.ParamValidation
 import com.example.hits.web.api.API_V1
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
-import io.mockk.mockk
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Import(HitControllerV1Test.TestConfig::class)
+@Import(TestConfig::class)
 class HitControllerV1Test : BehaviorSpec() {
 
     @Autowired
@@ -28,12 +26,22 @@ class HitControllerV1Test : BehaviorSpec() {
     @Autowired
     private lateinit var hitService: HitService
 
+    @Autowired
+    private lateinit var paramValidation: ParamValidation
+
     init {
         extension(SpringExtension)
 
         beforeSpec {
             every { hitService.increment("https://github.com/test/repo") } returns 42
-            every { hitService.validateParams("https://github.com/test/repo", any(), any(), any()) } returns null
+            every {
+                paramValidation.check(
+                    eq("https://github.com/test/repo"),
+                    any(),
+                    any(),
+                    any()
+                )
+            } returns null
         }
 
         given("GET $API_V1") {
@@ -53,11 +61,5 @@ class HitControllerV1Test : BehaviorSpec() {
                 }
             }
         }
-    }
-
-    @TestConfiguration
-    class TestConfig {
-        @Bean
-        fun hitService(): HitService = mockk(relaxed = true)
     }
 }

--- a/src/test/kotlin/com/example/hits/controller/TestConfig.kt
+++ b/src/test/kotlin/com/example/hits/controller/TestConfig.kt
@@ -1,0 +1,16 @@
+package com.example.hits.controller
+
+import com.example.hits.service.HitService
+import com.example.hits.service.ParamValidation
+import io.mockk.mockk
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+@TestConfiguration
+class TestConfig {
+    @Bean
+    fun hitService(): HitService = mockk(relaxed = true)
+
+    @Bean
+    fun paramValidation(): ParamValidation = mockk(relaxed = true)
+}


### PR DESCRIPTION
## 주요 변경 사항
- 파라미터 유효성 검증을 별도 `ParamValidation.kt`로 분리
- `svgResponse()`, `errorSvg()` 유틸 함수 도입으로 응답 형식 통일
- V1/V2 컨트롤러에서 검증 로직 간소화 및 title 자동 추출 처리
- `HitRepository` 내부에서 불필요한 increment 호출 제거 (사이드 이펙트 제거)

## 비고
- 모든 관련 테스트 코드 수정 및 통과 확인
- 배포 가능한 상태로 정리 완료